### PR TITLE
ci: use rainix static-checks reusable

### DIFF
--- a/.github/workflows/rainix-sol-static.yaml
+++ b/.github/workflows/rainix-sol-static.yaml
@@ -1,0 +1,5 @@
+name: rainix-sol-static
+on: [push]
+jobs:
+  static:
+    uses: rainlanguage/rainix/.github/workflows/rainix-sol-static.yaml@main

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        task: [rainix-sol-test, rainix-sol-static, rainix-sol-legal]
+        task: [rainix-sol-test, rainix-sol-legal]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
Switches the static-checks job to a thin wrapper that delegates to the reusable workflow added in rainlanguage/rainix#137. Same coverage; central source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
