### PR TITLE
ci: collapse three task wrappers into rainix-sol composite

### DIFF
--- a/.github/workflows/rainix-sol-legal.yaml
+++ b/.github/workflows/rainix-sol-legal.yaml
@@ -1,5 +1,0 @@
-name: rainix-sol-legal
-on: [push]
-jobs:
-  legal:
-    uses: rainlanguage/rainix/.github/workflows/rainix-sol-legal.yaml@main

--- a/.github/workflows/rainix-sol-static.yaml
+++ b/.github/workflows/rainix-sol-static.yaml
@@ -1,5 +1,0 @@
-name: rainix-sol-static
-on: [push]
-jobs:
-  static:
-    uses: rainlanguage/rainix/.github/workflows/rainix-sol-static.yaml@main

--- a/.github/workflows/rainix-sol-test.yaml
+++ b/.github/workflows/rainix-sol-test.yaml
@@ -1,6 +1,0 @@
-name: rainix-sol-test
-on: [push]
-jobs:
-  test:
-    uses: rainlanguage/rainix/.github/workflows/rainix-sol-test.yaml@main
-    secrets: inherit

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -1,0 +1,6 @@
+name: rainix
+on: [push]
+jobs:
+  rainix:
+    uses: rainlanguage/rainix/.github/workflows/rainix-sol.yaml@main
+    secrets: inherit


### PR DESCRIPTION
Drops the per-task wrappers in favour of the rainix-sol composite reusable from rainlanguage/rainix#140. Same coverage; one file instead of three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)